### PR TITLE
Add toString() methods to both currently utilized classes.

### DIFF
--- a/src/main/java/com/rlearning/controller/ColorPaletteController.java
+++ b/src/main/java/com/rlearning/controller/ColorPaletteController.java
@@ -38,7 +38,13 @@ public class ColorPaletteController {
   private static String recentSaveFileDir;
   private static BufferedWriter bw;
   private static FileWriter fw;
-
+  
+  @Override
+  public String toString(){
+  	return("Object base class: ColorPaletteController." + "\n" +
+               "This object has no instance variables.");
+    }
+  
   public static void saveColorPalette(ColorPicker colorPicker) {
     FileChooser fileChooser = new FileChooser();
     Stage saveFileStage = new Stage();

--- a/src/main/java/com/rlearning/controller/ColorPaletteController.java
+++ b/src/main/java/com/rlearning/controller/ColorPaletteController.java
@@ -39,6 +39,7 @@ public class ColorPaletteController {
   private static BufferedWriter bw;
   private static FileWriter fw;
   
+  // toString method for debugging purposes.
   @Override
   public String toString(){
   	return("Object base class: ColorPaletteController." + "\n" +

--- a/src/main/java/com/rlearning/view/SuperPixelEditorView.java
+++ b/src/main/java/com/rlearning/view/SuperPixelEditorView.java
@@ -41,6 +41,12 @@ public class SuperPixelEditorView extends Application {
   public static void setPixelColor(Color pixelColor) {
     SuperPixelEditorView.pixelColor = pixelColor;
   }
+  
+  @Override
+  public String toString(){
+  	return("Object base class: SuperPixelEditorView." + "\n" +
+               "This object has no instance variables. ");
+  }
 
   @Override
   public void start(Stage primaryStage) {

--- a/src/main/java/com/rlearning/view/SuperPixelEditorView.java
+++ b/src/main/java/com/rlearning/view/SuperPixelEditorView.java
@@ -41,7 +41,8 @@ public class SuperPixelEditorView extends Application {
   public static void setPixelColor(Color pixelColor) {
     SuperPixelEditorView.pixelColor = pixelColor;
   }
-  
+ 
+  // toString method for debugging purposes.
   @Override
   public String toString(){
   	return("Object base class: SuperPixelEditorView." + "\n" +


### PR DESCRIPTION
**Description**: toString() methods return a readable string displaying the class from which the object was instantiated, as well as an indication of the object's state (both toString() methods state there are no instance variables, as neither implemented class currently has any).

**Suggestion**: Since toString() overrides the default method within Java's "Object" class, care should be taken when implementing this new method, since it may render dependent code dysfunctional. To prevent this conflict, the new method could be renamed to something similar, that would not require overriding an existing method.